### PR TITLE
fix: bitsafe withdraw passes 0 amount, add Full Amount button

### DIFF
--- a/src/app/components/mint-unmint/components/unmint/components/withdraw-screen.tsx
+++ b/src/app/components/mint-unmint/components/unmint/components/withdraw-screen.tsx
@@ -30,7 +30,7 @@ export function WithdrawScreen({
 
   const { bitcoinPrice, depositLimit } = useContext(ProofOfReserveContext);
 
-  const { unmintStep } = useSelector((state: RootState) => state.mintunmint);
+  const { unmintStep, isBitsafeWithdraw } = useSelector((state: RootState) => state.mintunmint);
 
   const currentVault = unmintStep.vault;
 
@@ -90,6 +90,7 @@ export function WithdrawScreen({
         handleCancelButtonClick={handleCancel}
         depositLimit={depositLimit}
         isSubmitting={isSubmitting}
+        isBitsafeWithdraw={isBitsafeWithdraw}
       />
     </VStack>
   );

--- a/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.field-input.tsx
+++ b/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.field-input.tsx
@@ -1,4 +1,4 @@
-import { HStack, Image, NumberInput, NumberInputField, Text } from '@chakra-ui/react';
+import { Button, HStack, Image, NumberInput, NumberInputField, Text } from '@chakra-ui/react';
 import { FieldApi } from '@tanstack/react-form';
 
 interface TransactionFormFieldInputProps {
@@ -13,12 +13,14 @@ interface TransactionFormFieldInputProps {
     undefined,
     string
   >;
+  maxAmount?: number;
 }
 
 export function TransactionFormFieldInput({
   assetLogo,
   assetSymbol,
   formField,
+  maxAmount,
 }: TransactionFormFieldInputProps): React.JSX.Element {
   return (
     <HStack w={'100%'}>
@@ -37,6 +39,18 @@ export function TransactionFormFieldInput({
           <NumberInputField h={'25px'} color={'white.01'} fontWeight={'bold'} fontSize={'sm'} />
         </NumberInput>
       </HStack>
+      {maxAmount !== undefined && (
+        <Button
+          size={'xs'}
+          variant={'outline'}
+          color={'accent.lightBlue.01'}
+          borderColor={'accent.lightBlue.01'}
+          _hover={{ bg: 'white.04' }}
+          onClick={() => formField.handleChange(maxAmount.toString())}
+        >
+          Full Amount
+        </Button>
+      )}
       <Text fontSize={'sm'} fontWeight={'bold'} color={'white.01'}>
         {assetSymbol}
       </Text>

--- a/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.input.tsx
+++ b/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.input.tsx
@@ -5,8 +5,14 @@ import { TransactionFormFieldInput } from './transaction-screen.transaction-form
 import { TransactionFormInputUSDText } from './transaction-screen.transaction-form.input-usd-text';
 import { VaultTransactionFormWarning } from './transaction-screen.transaction-form.warning';
 
-const bitcoinFormProperties = {
+const bitcoinDepositFormProperties = {
   label: 'Deposit BTC',
+  logo: '/images/logos/bitcoin-logo.svg',
+  symbol: 'BTC',
+  color: 'orange.01',
+};
+const bitcoinWithdrawFormProperties = {
+  label: 'Withdraw BTC',
   logo: '/images/logos/bitcoin-logo.svg',
   symbol: 'BTC',
   color: 'orange.01',
@@ -20,7 +26,8 @@ const tokenFormProperties = {
 
 export function getFormProperties(
   flow: 'mint' | 'burn',
-  currentStep: number
+  currentStep: number,
+  isBitsafeWithdraw?: boolean
 ): {
   label: string;
   logo: string;
@@ -29,9 +36,12 @@ export function getFormProperties(
 } {
   switch (flow) {
     case 'mint':
-      return bitcoinFormProperties;
+      return bitcoinDepositFormProperties;
     case 'burn':
-      return currentStep === 1 ? bitcoinFormProperties : tokenFormProperties;
+      if (currentStep === 1) {
+        return isBitsafeWithdraw ? bitcoinWithdrawFormProperties : bitcoinDepositFormProperties;
+      }
+      return tokenFormProperties;
     default:
       throw new Error('Invalid Flow Type');
   }
@@ -43,6 +53,7 @@ interface TransactionFormInputFieldProps {
   formType: 'mint' | 'burn';
   currentBitcoinPrice: number;
   maxAmount?: number;
+  isBitsafeWithdraw?: boolean;
 }
 
 export function TransactionFormInputField({
@@ -51,8 +62,9 @@ export function TransactionFormInputField({
   currentBitcoinPrice,
   formType,
   maxAmount,
+  isBitsafeWithdraw,
 }: TransactionFormInputFieldProps): React.JSX.Element {
-  const formProperties = getFormProperties(formType, currentStep);
+  const formProperties = getFormProperties(formType, currentStep, isBitsafeWithdraw);
   return (
     <formAPI.Field name={'assetAmount'}>
       {field => (

--- a/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.input.tsx
+++ b/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.input.tsx
@@ -42,6 +42,7 @@ interface TransactionFormInputFieldProps {
   currentStep: number;
   formType: 'mint' | 'burn';
   currentBitcoinPrice: number;
+  maxAmount?: number;
 }
 
 export function TransactionFormInputField({
@@ -49,6 +50,7 @@ export function TransactionFormInputField({
   currentStep,
   currentBitcoinPrice,
   formType,
+  maxAmount,
 }: TransactionFormInputFieldProps): React.JSX.Element {
   const formProperties = getFormProperties(formType, currentStep);
   return (
@@ -69,6 +71,7 @@ export function TransactionFormInputField({
             assetLogo={formProperties.logo}
             assetSymbol={formProperties.symbol}
             formField={field}
+            maxAmount={maxAmount}
           />
           <TransactionFormInputUSDText
             errors={field.state.meta.errors}

--- a/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.progress-stack/components/transaction-screen.transaction-form.progress-stack.tsx
+++ b/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.progress-stack/components/transaction-screen.transaction-form.progress-stack.tsx
@@ -80,6 +80,7 @@ interface ProgressStackProps {
   currentBitcoinPrice: number;
   components: { A: ProgressStackItemProps; B: ProgressStackItemProps };
   maxAmount?: number;
+  isBitsafeWithdraw?: boolean;
 }
 
 const ProgressStack = ({
@@ -92,6 +93,7 @@ const ProgressStack = ({
   currentBitcoinPrice,
   components,
   maxAmount,
+  isBitsafeWithdraw,
 }: ProgressStackProps): React.JSX.Element => {
   const { A, B } = components;
 
@@ -105,6 +107,7 @@ const ProgressStack = ({
             currentBitcoinPrice={currentBitcoinPrice}
             formType={flow}
             maxAmount={maxAmount}
+            isBitsafeWithdraw={isBitsafeWithdraw}
           />
           <TransactionFormProgressStackItem
             label={B.label}
@@ -175,6 +178,7 @@ const ProgressStackByFlow = ({
       components={components}
       assetAmount={assetAmount}
       maxAmount={maxAmount}
+      isBitsafeWithdraw={isBitsafeWithdraw}
     />
   );
 };

--- a/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.progress-stack/components/transaction-screen.transaction-form.progress-stack.tsx
+++ b/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.progress-stack/components/transaction-screen.transaction-form.progress-stack.tsx
@@ -79,6 +79,7 @@ interface ProgressStackProps {
   activeStackItem: 0 | 1;
   currentBitcoinPrice: number;
   components: { A: ProgressStackItemProps; B: ProgressStackItemProps };
+  maxAmount?: number;
 }
 
 const ProgressStack = ({
@@ -90,6 +91,7 @@ const ProgressStack = ({
   activeStackItem,
   currentBitcoinPrice,
   components,
+  maxAmount,
 }: ProgressStackProps): React.JSX.Element => {
   const { A, B } = components;
 
@@ -102,6 +104,7 @@ const ProgressStack = ({
             currentStep={currentStep}
             currentBitcoinPrice={currentBitcoinPrice}
             formType={flow}
+            maxAmount={maxAmount}
           />
           <TransactionFormProgressStackItem
             label={B.label}
@@ -139,6 +142,8 @@ interface ProgressStackByFlowProps {
   confirmations?: number;
   currentBitcoinPrice: number;
   assetAmount?: number;
+  isBitsafeWithdraw?: boolean;
+  maxAmount?: number;
 }
 
 const ProgressStackByFlow = ({
@@ -148,9 +153,13 @@ const ProgressStackByFlow = ({
   confirmations = 0,
   currentBitcoinPrice,
   assetAmount,
+  isBitsafeWithdraw,
+  maxAmount,
 }: ProgressStackByFlowProps): React.JSX.Element => {
   const isConfirmed = confirmations >= 6;
-  const isIncludeForm = flow === 'mint' ? currentStep === 1 : currentStep === 0;
+  const isIncludeForm = flow === 'mint'
+    ? currentStep === 1
+    : currentStep === 0 || (!!isBitsafeWithdraw && currentStep === 1);
 
   const components = getComponents(flow, currentStep, isConfirmed);
   const activeStackItem = isIncludeForm || (flow === 'mint' && !isConfirmed) ? 0 : 1;
@@ -165,6 +174,7 @@ const ProgressStackByFlow = ({
       currentBitcoinPrice={currentBitcoinPrice}
       components={components}
       assetAmount={assetAmount}
+      maxAmount={maxAmount}
     />
   );
 };
@@ -204,6 +214,7 @@ interface TransactionFormProgressStackProps {
   valueLocked: number;
   valueMinted: number;
   vaultOutputValue?: number;
+  isBitsafeWithdraw?: boolean;
 }
 
 export const TransactionFormProgressStack = ({
@@ -215,6 +226,7 @@ export const TransactionFormProgressStack = ({
   vaultOutputValue,
   valueLocked,
   valueMinted,
+  isBitsafeWithdraw,
 }: TransactionFormProgressStackProps): React.JSX.Element => {
   return (
     <HStack
@@ -244,6 +256,8 @@ export const TransactionFormProgressStack = ({
           valueMinted,
           vaultOutputValue
         )}
+        isBitsafeWithdraw={isBitsafeWithdraw}
+        maxAmount={valueLocked}
       />
     </HStack>
   );

--- a/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.progress-stack/components/transaction-screen.transaction-form.progress-stack.tsx
+++ b/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.progress-stack/components/transaction-screen.transaction-form.progress-stack.tsx
@@ -160,9 +160,10 @@ const ProgressStackByFlow = ({
   maxAmount,
 }: ProgressStackByFlowProps): React.JSX.Element => {
   const isConfirmed = confirmations >= 6;
-  const isIncludeForm = flow === 'mint'
-    ? currentStep === 1
-    : currentStep === 0 || (!!isBitsafeWithdraw && currentStep === 1);
+  const isIncludeForm =
+    flow === 'mint'
+      ? currentStep === 1
+      : currentStep === 0 || (!!isBitsafeWithdraw && currentStep === 1);
 
   const components = getComponents(flow, currentStep, isConfirmed);
   const activeStackItem = isIncludeForm || (flow === 'mint' && !isConfirmed) ? 0 : 1;

--- a/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.protocol-fee-box.tsx
+++ b/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/components/transaction-screen.transaction-form.protocol-fee-box.tsx
@@ -14,6 +14,7 @@ interface TransactionFormProtocolFeeStackProps {
   bitcoinPrice?: number;
   protocolFeeBasisPoints?: number;
   isBitcoinWalletLoading: [boolean, string];
+  isBitsafeWithdraw?: boolean;
 }
 
 export function TransactionFormProtocolFeeStack({
@@ -24,11 +25,12 @@ export function TransactionFormProtocolFeeStack({
   bitcoinPrice,
   protocolFeeBasisPoints,
   isBitcoinWalletLoading,
+  isBitsafeWithdraw,
 }: TransactionFormProtocolFeeStackProps): React.JSX.Element | false {
   if (isBitcoinWalletLoading[0] || [0, 2].includes(currentStep)) return false;
 
   const amount =
-    flow === 'burn' && currentStep === 1
+    flow === 'burn' && currentStep === 1 && !isBitsafeWithdraw
       ? shiftValue(new Decimal(vault.valueLocked).minus(vault.valueMinted).toNumber())
       : shiftValue(assetAmount!);
 

--- a/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/transaction-screen.transaction-form.tsx
+++ b/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/transaction-screen.transaction-form.tsx
@@ -199,6 +199,7 @@ export function VaultTransactionForm({
           bitcoinPrice={currentBitcoinPrice}
           protocolFeeBasisPoints={vault?.btcMintFeeBasisPoints}
           isBitcoinWalletLoading={isBitcoinWalletLoading}
+          isBitsafeWithdraw={isBitsafeWithdraw}
         />
         <TransactionFormTransactionInformation
           flow={flow}

--- a/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/transaction-screen.transaction-form.tsx
+++ b/src/app/components/transaction-screen/transaction-screen.transaction-form/components/transaction-screen.transaction-form/transaction-screen.transaction-form.tsx
@@ -153,7 +153,7 @@ export function VaultTransactionForm({
       const burnAmount = new Decimal(vault.valueLocked).minus(vault.valueMinted).toNumber();
       const isWithdrawStep = flow === 'burn' && currentStep !== 0;
 
-      const amountToHandle = isWithdrawStep ? burnAmount : assetAmount;
+      const amountToHandle = isWithdrawStep && !isBitsafeWithdraw ? burnAmount : assetAmount;
 
       await handleButtonClick(amountToHandle);
     },
@@ -189,6 +189,7 @@ export function VaultTransactionForm({
           vaultOutputValue={vaultOutputValue}
           valueLocked={vault.valueLocked}
           valueMinted={vault.valueMinted}
+          isBitsafeWithdraw={isBitsafeWithdraw}
         />
         <TransactionFormProtocolFeeStack
           flow={flow}


### PR DESCRIPTION
## Summary
- **Bug fix**: The withdraw form's `onSubmit` handler always used `burnAmount` (`valueLocked - valueMinted`) at the withdraw step — which is `0` when they're equal. For bitsafe withdrawals, the form's actual input amount is now used instead.
- **Feature**: Show the BTC amount input field at the withdraw step when bitsafe mode is active (previously the input was hidden and the amount was hardcoded).
- **Feature**: Add a "Full Amount" button next to the input field that populates the full vault balance (`valueLocked`).

## Root cause
In `transaction-screen.transaction-form.tsx`, the submit handler had:
```typescript
const amountToHandle = isWithdrawStep ? burnAmount : assetAmount;
```
This always overrode the form input with `burnAmount = valueLocked - valueMinted = 0` at the withdraw step, regardless of what the user entered. The PSBT creation then received `withdrawAmount=0` and `selectUTXO` correctly rejected it.

## Test plan
- [ ] Toggle bitsafe on at burn step → click "Proceed to BTC Withdrawal"
- [ ] Verify the BTC amount input field is now visible at the withdraw step
- [ ] Click "Full Amount" button → verify it fills in `vault.valueLocked`
- [ ] Submit → verify the PSBT is created successfully with the correct amount
- [ ] Verify normal (non-bitsafe) burn/withdraw flow still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)